### PR TITLE
add almost sorted input and fix use of private stdlib-function

### DIFF
--- a/src/WSortView.cpp
+++ b/src/WSortView.cpp
@@ -21,6 +21,8 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************/
 
+#include <random>
+
 #include "WSortView.h"
 #include "SortAlgo.h"
 #include "WMain.h"
@@ -122,6 +124,7 @@ void WSortView::FillInputlist(wxControlWithItems* list)
     list->Append(_("Shuffled Cubic"));
     list->Append(_("Shuffled Quintic"));
     list->Append(_("Shuffled n-2 Equal"));
+    list->Append(_("Almost Ascending"));
 }
 
 void WSortView::FillData(unsigned int schema, size_t arraysize)
@@ -191,6 +194,17 @@ void WSortView::FillData(unsigned int schema, size_t arraysize)
         m_array[m_array.size()-1] = ArrayItem(arraysize);
 
         std::random_shuffle(m_array.begin(), m_array.end());
+    }
+    else if (schema == 6) // almost sorted values in [1,n]
+    {
+        for (size_t i = 0; i < m_array.size(); ++i)
+            m_array[i] = ArrayItem(i+1);
+        auto arraysize = m_array.size();
+        std::uniform_int_distribution<std::size_t> dist{0, arraysize};
+        std::random_device gen;
+        std::size_t permutations = arraysize / 30; // magic numbers ftw!
+        for(std::size_t i=0; i < permutations; ++i)
+            std::swap(m_array[dist(gen)], m_array[dist(gen)]);
     }
     else // fallback
     {

--- a/src/algorithms/wikisort.cpp
+++ b/src/algorithms/wikisort.cpp
@@ -72,7 +72,9 @@ size_t FloorPowerOfTwo (const size_t value) {
 // n^2 sorting algorithm used to sort tiny chunks of the full array
 template <typename Iterator, typename Comparison>
 void InsertionSort(Iterator begin, Iterator end, const Comparison compare) {
-    std::__insertion_sort(begin, end, compare);
+    for (auto it = begin; it != end; ++it) {
+        std::rotate(std::upper_bound(begin, it, *it, compare), it, it+1);
+    }
 }
 
 // swap a series of values in the array


### PR DESCRIPTION
I talked to you after todays meeting about the illegal use of std::__insertion_sort in the wikisort-implementation. This patch fixes this by using the insertion-sort-implementation from [here](http://en.cppreference.com/w/cpp/algorithm/rotate).

The other thing that this does is adding the possibility to start with an almost sorted range, which might be useful for algorithms like smoothsort and timsort.
