### PR TITLE
Fix string types for wxCmdLineEntryDesc

### DIFF
--- a/src/SortTest.cpp
+++ b/src/SortTest.cpp
@@ -144,16 +144,15 @@ int SortTestApp::OnRun()
 
 static const wxCmdLineEntryDesc g_cmdLineDesc[] =
 {
-    { wxCMD_LINE_SWITCH, _T("h"), _T("help"),
-      _T("displays help on the command line parameters"),
+    { wxCMD_LINE_SWITCH, "h", "help",
+      wxTRANSLATE("displays help on the command line parameters"),
       wxCMD_LINE_VAL_NONE, wxCMD_LINE_OPTION_HELP },
 
-    { wxCMD_LINE_PARAM, wxEmptyString, wxEmptyString,
-      _T("filter"),
+    { wxCMD_LINE_PARAM, "", "",
+      wxTRANSLATE("filter"),
       wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL },
 
-    { wxCMD_LINE_NONE, wxEmptyString, wxEmptyString,
-      wxEmptyString,
+    { wxCMD_LINE_NONE, "", "", "",
       wxCMD_LINE_VAL_NONE, wxCMD_LINE_PARAM_OPTIONAL }
 };
 


### PR DESCRIPTION
I wanted to create a package for the Arch User Repository, but the compilation failed at this point.
´wxCmdLineEntryDesc´ requires strings of the type `const char *` instead of `wxString`. This was changed more than 7 years ago: https://github.com/wxWidgets/wxWidgets/commit/0d5ab92f849923daa1418661aaf55135cddd4e47#diff-de95679acb93e808b03b6b960d9fb907
The compilation succeeds with this fix applied.
I used the `wxTRANSLATE()` macro (aka `gettext_noop()`) because this entry in the `wx-users` mailing list says that the `wxCmdLineParser` already includes calls to the appropiate gettext translation functions: http://avr-libc-dev-gnu.git.net/wx-users/msg03172.html
In general, I'm kind of a noob when it comes to C++, so you are welcome to critically review this fix.
I am using wxGTK 3.0.2.