### PR TITLE
Fix type specifiers for wxPrintf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ Makefile
 .deps
 *.o
 /src/sound-of-sorting
+/src/sorting-test
 
 # ignore backup files
 /src/wxg/*~

--- a/src/SortTest.cpp
+++ b/src/SortTest.cpp
@@ -131,7 +131,7 @@ int SortTestApp::OnRun()
                     all_good = false;
                 }
 
-                wxPrintf(_T("%d/i%d -> %ld ms. "), n, inputi, millitime);
+                wxPrintf(_T("%zu/i%zu -> %ld ms. "), n, inputi, millitime);
                 fflush(stdout);
             }
         }


### PR DESCRIPTION
`%d` is used by mistake, which causes assert errors.
For `size_t`, `%zu` should be used instead.