### PR TITLE
SortTest: add a header for wxPrintf

### DIFF
--- a/src/SortTest.cpp
+++ b/src/SortTest.cpp
@@ -21,8 +21,9 @@
  ******************************************************************************/
 
 #include <wx/app.h>
-#include <wx/stopwatch.h>
 #include <wx/cmdline.h>
+#include <wx/stopwatch.h>
+#include <wx/wxcrtvararg.h>
 
 #include "SortArray.h"
 #include "SortAlgo.h"


### PR DESCRIPTION
Without the header, an error `use of undeclared identifier 'wxPrintf'` appears.