### PR TITLE
cast parameter to `make_pair` for macOS

### DIFF
--- a/src/SortAlgo.cpp
+++ b/src/SortAlgo.cpp
@@ -575,7 +575,7 @@ std::pair<ssize_t,ssize_t> PartitionTernaryLL(SortArray& A, ssize_t lo, ssize_t 
     }
     A.unmark_all();
 
-    return std::make_pair(i,j);
+    return std::make_pair((ssize_t)i,j);
 }
 
 void QuickSortTernaryLL(SortArray& A, size_t lo, size_t hi)


### PR DESCRIPTION
`make_pair` on macOS can't handle volatile longs, so cast the first parameter to a long.

Change affects the `Quick Sort LL` sort.

Tested by manually exercising sorts in UI.

Compiled correctly on Linux; did not test by running the UI on Linux.

Did not compile or test on Windows.

Closes #29 